### PR TITLE
fix: remove exec() RCE, harden config API, fix platform portability

### DIFF
--- a/server.py
+++ b/server.py
@@ -151,6 +151,9 @@ def _metrics_watcher():
         if not METRICS_FILE.exists():
             continue
         try:
+            # Detect file truncation (e.g. new training run cleared metrics)
+            if METRICS_FILE.stat().st_size < pos:
+                pos = 0
             with open(METRICS_FILE, "r", encoding="utf-8") as f:
                 f.seek(pos)
                 for line in f:
@@ -220,20 +223,48 @@ def api_elo():
 
 @app.get("/api/config")
 def api_config():
-    ns: dict = {}
-    exec(CONFIG_FILE.read_text(encoding="utf-8"), ns)
-    return ns.get("CFG", {})
+    import ast, re
+    text = CONFIG_FILE.read_text(encoding="utf-8")
+    # Strip inline comments for safe parsing
+    lines = [line.split("#")[0] for line in text.splitlines()]
+    clean = "\n".join(lines)
+    match = re.search(r'CFG\s*=\s*(\{.*?\})', clean, re.DOTALL)
+    if not match:
+        raise HTTPException(status_code=500, detail="CFG not found in config.py")
+    try:
+        return ast.literal_eval(match.group(1))
+    except (ValueError, SyntaxError) as e:
+        raise HTTPException(status_code=500, detail=f"Failed to parse config: {e}")
 
 
 @app.post("/api/config")
 def api_config_write(cfg: dict):
     """Overwrite config.py with the staged values from the frontend."""
-    ns: dict = {}
-    exec(CONFIG_FILE.read_text(encoding="utf-8"), ns)
-    current = ns.get("CFG", {})
+    import ast, re
+    text = CONFIG_FILE.read_text(encoding="utf-8")
+    lines_raw = [line.split("#")[0] for line in text.splitlines()]
+    clean = "\n".join(lines_raw)
+    match = re.search(r'CFG\s*=\s*(\{.*?\})', clean, re.DOTALL)
+    if not match:
+        raise HTTPException(status_code=500, detail="CFG not found in config.py")
+    try:
+        current = ast.literal_eval(match.group(1))
+    except (ValueError, SyntaxError) as e:
+        raise HTTPException(status_code=500, detail=f"Failed to parse config: {e}")
     unknown = [k for k in cfg if k not in current]
     if unknown:
         raise HTTPException(status_code=400, detail=f"Unknown config keys: {unknown}")
+    # Validate types: allow int/float interchangeability, reject everything else
+    for k, v in cfg.items():
+        if isinstance(current[k], (int, float)) and isinstance(v, (int, float)):
+            continue
+        if isinstance(current[k], bool) and isinstance(v, bool):
+            continue
+        if isinstance(current[k], str) and isinstance(v, str):
+            continue
+        if type(v) != type(current[k]):
+            raise HTTPException(status_code=400,
+                detail=f"Invalid type for {k}: expected {type(current[k]).__name__}, got {type(v).__name__}")
     lines = [
         "# config.py — tunable hyperparameters for HexGo autotune",
         "# Edit this file to propose a new trial config.",

--- a/tune.py
+++ b/tune.py
@@ -30,7 +30,7 @@ CONFIG_FILE   = Path("config.py")
 CONFIG_BACKUP = Path("config.py.bak")
 TUNE_LOG      = Path("tune_log.jsonl")
 TUNE_RESULT   = Path("tune_result.json")
-PYTHON        = r"C:\Program Files\Python312\python.exe"
+PYTHON        = sys.executable
 
 
 def _read_elo(agent: str = "eisenstein_def") -> float | None:


### PR DESCRIPTION
## Summary

### Security: exec() → ast.literal_eval
Both `api_config()` and `api_config_write()` used `exec(CONFIG_FILE.read_text(), ns)` to parse config.py. This executes **arbitrary Python code** — if the dashboard is exposed beyond localhost or config.py is modified maliciously, any code in the file runs with server privileges. Replaced with `ast.literal_eval()` which only evaluates Python literals (dicts, strings, numbers, bools).

### Type validation on config write
The POST endpoint previously accepted any JSON value for any key. Now validates that submitted types match existing config types (with int/float interchangeability allowed). Rejects e.g. `"LR": "not_a_number"` or `"BATCH_SIZE": [1,2,3]` with a 400 error.

### Metrics watcher truncation fix
`_metrics_watcher` tracked file position with `pos` but never checked if the file was truncated (e.g., new training run). If `metrics.jsonl` shrank, `f.seek(pos)` would seek past EOF and all new data written below the old position was silently skipped. Now resets `pos = 0` when file size < pos.

### Platform portability
`tune.py` hardcoded `PYTHON = r"C:\Program Files\Python312\python.exe"` — fails on macOS/Linux. Changed to `sys.executable` (matching `server.py`'s approach).

## Test plan
- [ ] `GET /api/config` returns correct dict
- [ ] `POST /api/config` with valid values succeeds  
- [ ] `POST /api/config` with `{"LR": "bad"}` returns 400
- [ ] `POST /api/config` with `{"UNKNOWN_KEY": 1}` returns 400
- [ ] Truncate `metrics.jsonl` while dashboard is running — new metrics appear
- [ ] `python tune.py --help` works on macOS/Linux

🤖 Generated with [Claude Code](https://claude.com/claude-code)