### PR TITLE
[codex] fix local Python launcher paths

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,12 +20,12 @@ The mathematical framing is not cosmetic — it drives three concrete engineerin
 
 ## Python interpreter
 
-**Always use `C:\Users\landa\AppData\Local\Programs\Python\Python312\python.exe`** — this is the only install with
+**Always use `C:\Program Files\Python312\python.exe`** — this is the install with
 torch+CUDA, fastapi, and uvicorn. Running `python` or `py` from PowerShell will pick up
 the wrong interpreter and fail with `ModuleNotFoundError`.
 
 - **bash/WSL**: use `bash run.sh <script.py>` (already hard-codes the path)
-- **PowerShell**: use `run.bat <script.py>` or `& "C:\Users\landa\AppData\Local\Programs\Python\Python312\python.exe" <script.py>`
+- **PowerShell**: use `run.bat <script.py>` or `& "C:\Program Files\Python312\python.exe" <script.py>`
 
 ---
 

--- a/autoresearch/program.md
+++ b/autoresearch/program.md
@@ -9,8 +9,8 @@ You run experiments in a loop: **propose change → train → evaluate → keep/
 
 ## Environment
 
-- **Project**: `C:\Users\landa\.claude\projects\hexgo2`
-- **Python**: `C:\Users\landa\AppData\Local\Programs\Python\Python312\python.exe`
+- **Project**: `C:\Users\Leon\Desktop\Psychograph\hexgo`
+- **Python**: `C:\Program Files\Python312\python.exe`
 - **GPU**: RTX 5070 Ti (16GB VRAM)
 - **Training**: `bash run.sh train.py --gens <N> --sims 200 --games 128`
 - **Experiment runner**: `bash run.sh autoresearch/run_trial.py --gens 10`

--- a/run.bat
+++ b/run.bat
@@ -1,4 +1,4 @@
 @echo off
 REM HexGo launcher — always uses Python 3.12 (has torch+CUDA, fastapi, uvicorn)
 REM Usage: run.bat <script.py> [args...]
-"C:\Users\landa\AppData\Local\Programs\Python\Python312\python.exe" %*
+"C:\Program Files\Python312\python.exe" %*

--- a/run.sh
+++ b/run.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 # Usage: bash run.sh <script.py> [args...]
-PY="/c/Users/landa/AppData/Local/Programs/Python/Python312/python.exe"
+PY="/c/Program Files/Python312/python.exe"
 cd "$(dirname "$0")"
 "$PY" "$@"

--- a/train.sh
+++ b/train.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 # Always use Python 3.12 for training (needs CUDA torch)
-PY="/c/Users/landa/AppData/Local/Programs/Python/Python312/python.exe"
+PY="/c/Program Files/Python312/python.exe"
 cd "$(dirname "$0")"
-"$PY" train.py --gens 2 --sims 2 --games 6 "$@" 
+"$PY" train.py --gens 2 --sims 2 --games 6 "$@"


### PR DESCRIPTION
## Summary

- Update launcher scripts and agent docs from the stale per-user Python path to the installed Python 3.12 executable at `C:\Program Files\Python312\python.exe`.
- Update the AutoResearch project path to this checkout: `C:\Users\Leon\Desktop\Psychograph\hexgo`.
- Trim trailing whitespace in `train.sh` while touching the launcher path.

## Validation

- `git diff --cached --check`
- `.\run.bat -c "import sys; print(sys.executable)"` -> `C:\Program Files\Python312\python.exe`
- `.\run.bat -m pip show torch` -> `torch 2.6.0+cu124`

## Notes

`gh auth status` reports an invalid stored token, but `git push` succeeded through the configured Git credential flow.